### PR TITLE
Support Baseline Model Switching via Environment Variables #8

### DIFF
--- a/python/examples/chat_example.py
+++ b/python/examples/chat_example.py
@@ -10,13 +10,17 @@ def main():
     # You can set API keys via environment variables:
     # export CACHEAI_API_KEY="your-cacheai-api-key"
     # export CACHEAI_BASELINE_MODEL_PROVIDER="openai"
+    # export CACHEAI_BASELINE_MODEL="google/gemma-3-27b-it"
     # export CACHEAI_BASELINE_MODEL_API_KEY="your-baseline-model-api-key"
+    # export CACHEAI_BASELINE_MODEL_BASE_URL="http://localhost:8011/v1"
     
     try:
         client = Client(
             api_key=os.getenv("CACHEAI_API_KEY", "your-cacheai-api-key"),
             baseline_model_provider=os.getenv("CACHEAI_BASELINE_MODEL_PROVIDER", "openai"),
+            baseline_model=os.getenv("CACHEAI_BASELINE_MODEL"),
             baseline_model_api_key=os.getenv("CACHEAI_BASELINE_MODEL_API_KEY", "your-baseline-model-api-key"),
+            baseline_model_base_url=os.getenv("CACHEAI_BASELINE_MODEL_BASE_URL"),
         )
         
         print("=" * 60)

--- a/python/src/cacheai/client.py
+++ b/python/src/cacheai/client.py
@@ -52,6 +52,7 @@ class Client:
         max_retries: int = 2,
         enable_cache: bool = True,
         baseline_model_provider: Optional[str] = None,
+        baseline_model: Optional[str] = None,
         baseline_model_api_key: Optional[str] = None,
         baseline_model_base_url: Optional[str] = None,
     ) -> None:
@@ -65,6 +66,7 @@ class Client:
             max_retries: Maximum number of retries for failed requests
             enable_cache: Enable CacheAI semantic caching (default: True)
             baseline_model_provider: Baseline LLM provider (openai, anthropic, google, etc.)
+            baseline_model: Baseline LLM model name (e.g., google/gemma-3-27b-it, gpt-3.5-turbo)
             baseline_model_api_key: Baseline LLM API key
             baseline_model_base_url: Custom baseline LLM endpoint URL
         """
@@ -88,12 +90,13 @@ class Client:
 
         # Baseline model configuration
         self.baseline_model_provider = baseline_model_provider or os.getenv("CACHEAI_BASELINE_MODEL_PROVIDER")
+        self.baseline_model = baseline_model or os.getenv("CACHEAI_BASELINE_MODEL")
         self.baseline_model_api_key = baseline_model_api_key or os.getenv("CACHEAI_BASELINE_MODEL_API_KEY")
         self.baseline_model_base_url = baseline_model_base_url or os.getenv("CACHEAI_BASELINE_MODEL_BASE_URL")
 
         logger.info(f"Initializing Cache AI client: base_url={self.base_url}, enable_cache={self.enable_cache}")
-        if self.baseline_model_provider:
-            logger.debug(f"Baseline model configured: provider={self.baseline_model_provider}, base_url={self.baseline_model_base_url or 'default'}")
+        if self.baseline_model_provider or self.baseline_model:
+            logger.debug(f"Baseline model configured: provider={self.baseline_model_provider}, model={self.baseline_model}, base_url={self.baseline_model_base_url or 'default'}")
 
         # Setup session with retry strategy
         self._session = requests.Session()
@@ -125,6 +128,8 @@ class Client:
         # Add baseline configuration headers
         if self.baseline_model_provider:
             headers["X-CacheAI-Baseline-Model-Provider"] = self.baseline_model_provider
+        if self.baseline_model:
+            headers["X-CacheAI-Baseline-Model"] = self.baseline_model
         if self.baseline_model_api_key:
             headers["X-CacheAI-Baseline-Model-API-Key"] = self.baseline_model_api_key
         if self.baseline_model_base_url:

--- a/python/src/cacheai/resources/chat.py
+++ b/python/src/cacheai/resources/chat.py
@@ -125,6 +125,10 @@ class Completions:
         baseline_model_api_key = self._client.baseline_model_api_key
         baseline_model_base_url = self._client.baseline_model_base_url
         
+        # Use client.baseline_model if set, otherwise use the model parameter
+        actual_model = self._client.baseline_model or model
+        logger.info(f"Baseline model selection: client.baseline_model={self._client.baseline_model}, model param={model}, actual_model={actual_model}")
+        
         # Validate baseline configuration
         if not baseline_model_provider:
             raise ValidationError(
@@ -140,7 +144,7 @@ class Completions:
         
         # Call Baseline model
         return call_baseline_model(
-            model=model,
+            model=actual_model,
             messages=messages,
             baseline_model_provider=baseline_model_provider,
             baseline_model_api_key=baseline_model_api_key,

--- a/python/src/cacheai/utils/baseline_model.py
+++ b/python/src/cacheai/utils/baseline_model.py
@@ -36,14 +36,14 @@ def call_baseline_model(
         ValidationError: If provider is unsupported or config is invalid
         APIError: If API call fails
     """
-    # Set default base URL based on provider
+    # Validate baseline_model_base_url is required
     if not baseline_model_base_url:
-        if baseline_model_provider == "openai":
-            baseline_model_base_url = "https://api.openai.com/v1"
-        else:
-            raise ValidationError(f"Unsupported baseline model provider: {baseline_model_provider}")
+        raise ValidationError(
+            "baseline_model_base_url is required for Baseline model calls. "
+            "Set baseline_model_base_url in Client or CACHEAI_BASELINE_MODEL_BASE_URL env var."
+        )
         
-    logger.info(f"Calling Baseline model: provider={baseline_model_provider}, model={model}")
+    logger.info(f"Calling Baseline model: provider={baseline_model_provider}, base_url={baseline_model_base_url}, model={model}")
     
     # Call Baseline model API (OpenAI-compatible)
     url = f"{baseline_model_base_url.rstrip('/')}/chat/completions"


### PR DESCRIPTION
Support Baseline Model Switching via Environment Variables #8

## Summary:

Added support for `CACHEAI_BASELINE_MODEL` environment variable to enable flexible baseline model switching. The `client.baseline_model` setting now takes precedence over the `model` parameter in `chat.completions.create()`.

## Details:
- Added `baseline_model` parameter to Client class `__init__()` method [1]
- Added environment variable `CACHEAI_BASELINE_MODEL` support with `self.baseline_model = baseline_model or os.getenv("CACHEAI_BASELINE_MODEL")` [1]
- Updated docstring to document new `baseline_model` parameter [1]
- Updated log output to display `baseline_model` configuration [1]
- Modified `_call_baseline_model()` to prioritize `client.baseline_model` over `model` parameter [2]
- Added model selection logic: `actual_model = self._client.baseline_model or model` [2]
- Added log output to track which model was selected [2]
- Changed `baseline_model_base_url` to required parameter (removed default values) [3]
- Added validation to ensure `baseline_model_base_url` is provided [3]
- Updated log output to display provider, model, and url [3]
- Updated example to use environment variables for baseline model configuration [4]
- Added `baseline_model` variable to get model name from environment [4]
- Updated comments to document custom endpoint usage (e.g., local vLLM, Ollama) [4]

## Changes:

[1] `python/src/cacheai/client.py` (Modified)
[2] `python/src/cacheai/resources/chat.py` (Modified)
[3] `python/src/cacheai/utils/baseline_model.py` (Modified)
[4] `python/examples/chat_example.py` (Modified)

---

## 日本語版

環境変数によるBaseline Modelの切り替えをサポート #8

## 概要:

`CACHEAI_BASELINE_MODEL`環境変数のサポートを追加し、baseline modelの柔軟な切り替えを可能にしました。`client.baseline_model`の設定が`chat.completions.create()`の`model`パラメータより優先されます。

## 詳細:
- Clientクラスの`__init__()`メソッドに`baseline_model`パラメータを追加 [1]
- `self.baseline_model = baseline_model or os.getenv("CACHEAI_BASELINE_MODEL")`により環境変数`CACHEAI_BASELINE_MODEL`のサポートを追加 [1]
- ログ出力を更新し、`baseline_model`設定を表示 [1]
- `_call_baseline_model()`を修正し、`client.baseline_model`を`model`パラメータより優先 [2]
- モデル選択ロジックを追加: `actual_model = self._client.baseline_model or model` [2]
- どのmodelが選択されたかを追跡するログ出力を追加 [2]
- `baseline_model_base_url`を必須パラメータに変更（デフォルト値を削除） [3]
- `baseline_model_base_url`が提供されていることを確認するバリデーションを追加 [3]
- `baseline_model_base_url`が必須であることを明確化するようdocstringを更新 [3]
- provider、model、urlを表示するようログ出力を更新 [3]
- サンプルコードを更新し、環境変数でbaseline model設定を行う例を追加 [4]
- 環境変数からモデル名を取得する`baseline_model`変数を追加 [4]
- カスタムエンドポイント使用例（ローカルvLLM、Ollama等）をコメントに追加 [4]

## Changes:

[1] `python/src/cacheai/client.py` (変更)
[2] `python/src/cacheai/resources/chat.py` (変更)
[3] `python/src/cacheai/utils/baseline_model.py` (変更)
[4] `python/examples/chat_example.py` (変更)