### PR TITLE
Add Cache Registration Feature to Python API #11

### DIFF
--- a/python/src/cacheai/client.py
+++ b/python/src/cacheai/client.py
@@ -8,6 +8,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from cacheai.resources import Chat
+from cacheai.resources.cache import Cache
 from cacheai.exceptions import (
     CacheAIError,
     AuthenticationError,
@@ -112,6 +113,7 @@ class Client:
 
         # Initialize resources
         self.chat = Chat(self)
+        self.cache = Cache(self)
 
     def _get_headers(self, extra_headers: Optional[Dict[str, str]] = None) -> Dict[str, str]:
         """Build request headers."""
@@ -271,6 +273,37 @@ class Client:
         except requests.exceptions.ConnectionError as e:
             raise ConnectionError(f"Connection failed: {e}")
         except requests.exceptions.RequestException as e:
+            raise CacheAIError(f"Request failed: {e}")
+
+    def _update(self, path: str, **kwargs: Any) -> Dict[str, Any]:
+        """Make an update request for cache operations."""
+        url = f"{self.base_url}{path}"
+        headers = self._get_headers(kwargs.pop("headers", None))
+
+        logger.debug(f"Making update request: url={url}")
+
+        try:
+            response = self._session.put(
+                url,
+                headers=headers,
+                timeout=self.timeout,
+                **kwargs,
+            )
+
+            if not response.ok:
+                self._handle_error_response(response)
+
+            logger.debug(f"Update request successful: status={response.status_code}")
+            return response.json()
+
+        except requests.exceptions.Timeout as e:
+            logger.error(f"Request timeout: url={url}, error={e}")
+            raise TimeoutError(f"Request timed out: {e}")
+        except requests.exceptions.ConnectionError as e:
+            logger.error(f"Connection error: url={url}, error={e}")
+            raise ConnectionError(f"Connection failed: {e}")
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Request failed: url={url}, error={e}")
             raise CacheAIError(f"Request failed: {e}")
 
     def close(self) -> None:

--- a/python/src/cacheai/resources/cache.py
+++ b/python/src/cacheai/resources/cache.py
@@ -1,0 +1,110 @@
+"""CacheAI Cache Management API resource."""
+
+from typing import Optional, Dict, Any
+import logging
+
+from cacheai.exceptions import (
+    AuthenticationError,
+    NotFoundError,
+    PermissionDeniedError,
+    ValidationError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class Cache:
+    """Cache management resource."""
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    def update(
+        self,
+        cache_key: str,
+        *,
+        output: Optional[str] = None,
+        model_id: Optional[str] = None,
+        converter_type: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        """
+        Update cache entry by cache_key.
+
+        Args:
+            cache_key: Cache key (CacheDB key / hash value from CacheKeyConverter)
+            output: Updated generated result
+            model_id: Updated model ID
+            converter_type: Updated converter type
+            **kwargs: Additional fields to update
+
+        Returns:
+            Update result dictionary
+
+        Raises:
+            ValidationError: If no fields to update are provided
+            AuthenticationError: If authentication fails
+            PermissionDeniedError: If user doesn't own the cache
+            NotFoundError: If cache entry not found
+        """
+        logger.info(f"Updating cache by cache_key: {cache_key}")
+
+        # Build request payload
+        payload = {}
+
+        # Add update fields
+        if output is not None:
+            payload["output"] = output
+        if model_id is not None:
+            payload["model_id"] = model_id
+        if converter_type is not None:
+            payload["converter_type"] = converter_type
+
+        # Add additional fields
+        payload.update(kwargs)
+
+        # Validate that there are fields to update
+        if not payload:
+            raise ValidationError(
+                "At least one field to update must be provided (output, model_id, converter_type, etc.)"
+            )
+
+        logger.debug(f"Update payload: {payload}")
+
+        # Make API request using update method
+        try:
+            response_data = self._client._update(f"/cache/{cache_key}", json=payload)
+            logger.info(f"Cache update successful: {response_data.get('cache_key')}")
+            logger.debug(f"Updated fields: {response_data.get('updated_fields')}")
+            return response_data
+        except Exception as e:
+            logger.error(f"Cache update failed: {e}")
+            raise
+
+    def get(
+        self,
+        cache_key: str,
+    ) -> Dict[str, Any]:
+        """
+        Get cache entry by cache_key.
+
+        Args:
+            cache_key: Cache key (CacheDB key)
+
+        Returns:
+            Cache entry data
+
+        Raises:
+            AuthenticationError: If authentication fails
+            PermissionDeniedError: If user doesn't have access
+            NotFoundError: If cache entry not found
+        """
+        logger.info(f"Getting cache: cache_key={cache_key}")
+
+        try:
+            response_data = self._client._get(f"/cache/{cache_key}")
+            logger.debug(f"Cache retrieved: {response_data}")
+            return response_data
+        except Exception as e:
+            logger.error(f"Cache retrieval failed: {e}")
+            raise

--- a/python/src/cacheai/resources/chat.py
+++ b/python/src/cacheai/resources/chat.py
@@ -94,8 +94,36 @@ class Completions:
             # Check if Baseline model is required (no cache hit)
             if response_data.get("requires_baseline_model"):
                 logger.info("No cache hit, calling Baseline model")
+                cache_key = response_data.get("cache_key")
+                
+                if not cache_key:
+                    raise CacheAIError("No cache_key in response from WebAPI /chat/completions")
+                
+                logger.info(f"Cache key from WebAPI: {cache_key}")
+                
                 # Call Baseline model
                 response_data = self._call_baseline_model(model, messages, payload)
+                logger.info("Baseline model called successfully")
+                
+                # Update cache with baseline model response
+                try:
+                    logger.info(f"Updating cache with baseline model response: cache_key={cache_key}")
+                    output_text = response_data["choices"][0]["message"]["content"]
+                    
+                    # Format messages as prompt string
+                    prompt_str = self._format_messages_to_prompt(messages)
+                    
+                    # Update cache using cache.update()
+                    update_result = self._client.cache.update(
+                        cache_key,
+                        output=output_text,
+                        model_id=model,
+                        prompt=prompt_str
+                    )
+                    logger.info(f"Cache updated successfully")
+                except Exception as e:
+                    logger.error(f"Failed to update cache: {e}")
+                    # Continue even if cache update fails
             else:
                 logger.info(f"Cache hit or direct response (requires_baseline_model={response_data.get('requires_baseline_model')})")
             
@@ -143,7 +171,7 @@ class Completions:
             )
         
         # Call Baseline model
-        return call_baseline_model(
+        response_data = call_baseline_model(
             model=actual_model,
             messages=messages,
             baseline_model_provider=baseline_model_provider,
@@ -154,6 +182,26 @@ class Completions:
                if k in ["temperature", "max_tokens", "top_p", 
                        "frequency_penalty", "presence_penalty", "stop"]}
         )
+        
+        return response_data
+
+    def _format_messages_to_prompt(self, messages: List[Dict[str, str]]) -> str:
+        """
+        Convert messages list to a single prompt string.
+        
+        Args:
+            messages: List of message dictionaries with 'role' and 'content'
+            
+        Returns:
+            Formatted prompt string
+        """
+        prompt_parts = []
+        for msg in messages:
+            role = msg.get("role", "")
+            content = msg.get("content", "")
+            if role and content:
+                prompt_parts.append(f"{role}: {content}")
+        return "\n".join(prompt_parts)
 
     def _stream(self, payload: Dict[str, Any]) -> Iterator[ChatCompletionChunk]:
         """Stream chat completion chunks."""


### PR DESCRIPTION
Add Cache Registration Feature to Python API

## Summary:

Implemented cache registration functionality to store baseline model responses in CacheAI. When a cache miss occurs, the Python API now calls the baseline model and registers the response using `cache.update()` via `PUT /cache/{cache_key}` endpoint.

## Details:
- Added Cache resource class with `update()` and `get()` methods [1]
- `update()` method sends PUT HTTP request to `/cache/{cache_key}` to register cache entries [1]
- `get()` method calls `GET /cache/{cache_key}` to retrieve cache entries [1]
- Added Cache resource to Client class with import and initialization [2]
- Modified chat completion flow to call `cache.update()` after baseline model response [3]
- Added `_format_messages_to_prompt()` helper method to convert messages list to prompt string [3]
- Added error handling to continue operation even if cache update fails [3]

## Changes:

[1] `python/src/cacheai/resources/cache.py` (New)
[2] `python/src/cacheai/client.py` (Modified)
[3] `python/src/cacheai/resources/chat.py` (Modified)

---

## 日本語版

Cache登録機能をPython APIに追加

## 概要:

CacheAIにbaseline modelのレスポンスを保存するキャッシュ登録機能を実装しました。キャッシュミス時、Python APIはbaseline modelを呼び出し、`cache.update()`を使用して`PUT /cache/{cache_key}`エンドポイント経由でレスポンスを登録します。

## 詳細:
- `update()`と`get()`メソッドを持つCacheリソースクラスを追加 [1]
- `update()`メソッドはPUT HTTPリクエストで`/cache/{cache_key}`にキャッシュエントリを登録 [1]
- `get()`メソッドは`GET /cache/{cache_key}`を呼び出してキャッシュエントリを取得 [1]
- ClientクラスにCacheリソースをインポートおよび初期化で追加 [2]
- baseline modelレスポンス後に`cache.update()`を呼び出すようchat completionフローを修正 [3]
- messagesリストをprompt文字列に変換する`_format_messages_to_prompt()`ヘルパーメソッドを追加 [3]
- キャッシュ更新が失敗しても動作を継続するエラーハンドリングを追加 [3]

## Changes:

[1] `python/src/cacheai/resources/cache.py` (新規作成)
[2] `python/src/cacheai/client.py` (変更)
[3] `python/src/cacheai/resources/chat.py` (変更)