### PR TITLE
Fix: enable retries for PUT (cache update) requests

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "black>=23.0.0",
     "ruff>=0.1.0",
     "types-requests>=2.28.0",
+    "responses"
 ]
 
 [project.urls]

--- a/python/src/cacheai/client.py
+++ b/python/src/cacheai/client.py
@@ -105,7 +105,7 @@ class Client:
             total=max_retries,
             backoff_factor=1,
             status_forcelist=[429, 500, 502, 503, 504],
-            allowed_methods=["GET", "POST"],
+            allowed_methods=["GET", "POST","PUT"],
         )
         adapter = HTTPAdapter(max_retries=retry_strategy)
         self._session.mount("http://", adapter)

--- a/python/tests/test_retry_put.py
+++ b/python/tests/test_retry_put.py
@@ -1,0 +1,51 @@
+import json
+
+import pytest
+import responses
+
+from cacheai import Client
+
+
+@responses.activate
+def test_put_is_retried_on_503_then_succeeds():
+    """
+    This test proves retries for PUT work by simulating:
+      1) 503 Service Unavailable
+      2) 200 OK
+    and asserting two PUT calls were made.
+
+    NOTE: This will FAIL until you add "PUT" to Retry.allowed_methods in client.py.
+    """
+    base_url = "https://api.cacheai.tech/v1"
+    cache_key = "abc123"
+    url = f"{base_url}/cache/{cache_key}"
+
+    # 1st response: transient failure => should trigger retry
+    responses.add(
+        method=responses.PUT,
+        url=url,
+        status=503,
+        json={"error": {"message": "temporary outage"}},
+        content_type="application/json",
+    )
+
+    # 2nd response: success
+    responses.add(
+        method=responses.PUT,
+        url=url,
+        status=200,
+        json={"cache_key": cache_key, "updated_fields": ["output"]},
+        content_type="application/json",
+    )
+
+    client = Client(api_key="test-key", base_url=base_url, max_retries=1)
+
+    result = client.cache.update(cache_key, output="hello")
+
+    assert result["cache_key"] == cache_key
+    assert len(responses.calls) == 2
+    assert responses.calls[0].request.method == "PUT"
+    assert responses.calls[1].request.method == "PUT"
+
+    body = json.loads(responses.calls[1].request.body.decode("utf-8"))
+    assert body["output"] == "hello"


### PR DESCRIPTION
- Adds `PUT` to `urllib3.Retry.allowed_methods` in `Client` so `cache.update()` benefits from retries on `429/5xx`.
- Adds a unit test that mocks `PUT /cache/{key}` returning `503` then `200` and asserts the request is retried and succeeds.

fix #13 
